### PR TITLE
Bug v6conf verify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ typings/
 .db
 glass_config.json
 config_backups
+
+# Dev
+development

--- a/routes/dhcpv6_config_save.js
+++ b/routes/dhcpv6_config_save.js
@@ -18,7 +18,7 @@ router.post('/', authCheck, function (req, res, next) {
   var exec = require('child_process').exec
 
   exec(
-    '/usr/sbin/dhcpd -t -cf ./syntax_verify_config > verify_output 2> verify_output',
+    '/usr/sbin/dhcpd -6 -t -cf ./syntax_verify_config > verify_output 2> verify_output',
     function (err, stdout, stderr) {
       var output = fs.readFileSync('./verify_output', 'utf8')
 


### PR DESCRIPTION
- fixes bug with the syntax verification when trying to save v6 files (adds `-6` flag to the verification command to turn on "v6 mode"). 
- add `development` folder to `.gitignore`