### PR TITLE
Bug Fix - Image Uploads

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fiberglass",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "private": true,
   "scripts": {
     "start": "node ./bin/www"

--- a/public/templates/index.html
+++ b/public/templates/index.html
@@ -182,7 +182,7 @@
                         target="bsb">AdminBSB - Material Design</a>
                 </div>
                 <div class="version">
-                    <b>Version: </b> 2.3.0
+                    <b>Version: </b> 2.3.1
                 </div>
             </div>
             <!-- #Footer -->

--- a/routes/glass_settings_save.js
+++ b/routes/glass_settings_save.js
@@ -6,11 +6,17 @@ var express = require('express')
 var router = express.Router()
 var authGuard = require('../core/auth-guard.js')
 var multer = require('multer')
+var fs = require('fs')
 
 var authCheck = authGuard({ groupPermissionLevel: 'admin' })
 
 var storage = multer.diskStorage({
   destination: function (req, file, cb) {
+    // make sure uploads dir is there
+    if (!fs.existsSync('./public/images/uploads')) {
+      fs.mkdirSync('./public/images/uploads')
+    }
+
     cb(null, 'public/images/uploads/')
   },
   filename: function (req, file, cb) {
@@ -29,8 +35,6 @@ router.post(
   function (req, res, next) {
     var request = req.body
     var json_file = require('jsonfile')
-
-    console.log(request)
 
     var glass_config = json_file.readFileSync('config/glass_config.json')
 


### PR DESCRIPTION
In the admin configuration settings, make sure the uploads directory exists before the user tries to upload a logo or favicon file.

Fixes a bug where the feature could fail to work, for example, on new installs because the uploads directory was not created.